### PR TITLE
update citation to official AAAI 2026 proceedings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ This repository contains the official implementation of the paper, "**Joint-GCG:
 
 If you find this work useful, please consider citing the following paper:
 ```bibtex
-@misc{wang2025jointgcgunifiedgradientbasedpoisoning,
-      title={Joint-GCG: Unified Gradient-Based Poisoning Attacks on Retrieval-Augmented Generation Systems}, 
-      author={Haowei Wang and Rupeng Zhang and Junjie Wang and Mingyang Li and Yuekai Huang and Dandan Wang and Qing Wang},
-      year={2025},
-      eprint={2506.06151},
-      archivePrefix={arXiv},
-      primaryClass={cs.CR},
-      url={https://arxiv.org/abs/2506.06151}, 
+@inproceedings{wang2026jointgcg,
+  title     = {Joint-{GCG}: Unified Gradient-Based Poisoning Attacks on Retrieval-Augmented Generation ({RAG}) Systems},
+  author    = {Wang, Haowei and Zhang, Rupeng and Wang, Junjie and Li, Mingyang and Huang, Yuekai and Wang, Dandan and Wang, Qing},
+  booktitle = {Proceedings of the {AAAI} Conference on Artificial Intelligence},
+  year      = {2026},
+  volume    = {40},
+  number    = {42},
+  pages     = {35793--35801},
+  doi       = {10.1609/aaai.v40i42.40893},
+  url       = {https://ojs.aaai.org/index.php/AAAI/article/view/40893}
 }
 ```

--- a/pages/src/pages/index.mdx
+++ b/pages/src/pages/index.mdx
@@ -236,13 +236,15 @@ In this paper, we introduced Joint-GCG, a novel framework that unifies gradient-
 ## BibTeX Citation
 
 ```bibtex
-@misc{wang2025jointgcgunifiedgradientbasedpoisoning,
-      title={Joint-GCG: Unified Gradient-Based Poisoning Attacks on Retrieval-Augmented Generation Systems}, 
-      author={Haowei Wang and Rupeng Zhang and Junjie Wang and Mingyang Li and Yuekai Huang and Dandan Wang and Qing Wang},
-      year={2025},
-      eprint={2506.06151},
-      archivePrefix={arXiv},
-      primaryClass={cs.CR},
-      url={https://arxiv.org/abs/2506.06151}, 
+@inproceedings{wang2026jointgcg,
+  title     = {Joint-{GCG}: Unified Gradient-Based Poisoning Attacks on Retrieval-Augmented Generation ({RAG}) Systems},
+  author    = {Wang, Haowei and Zhang, Rupeng and Wang, Junjie and Li, Mingyang and Huang, Yuekai and Wang, Dandan and Wang, Qing},
+  booktitle = {Proceedings of the {AAAI} Conference on Artificial Intelligence},
+  year      = {2026},
+  volume    = {40},
+  number    = {42},
+  pages     = {35793--35801},
+  doi       = {10.1609/aaai.v40i42.40893},
+  url       = {https://ojs.aaai.org/index.php/AAAI/article/view/40893}
 }
 ```


### PR DESCRIPTION
Citation updates:

* Updated the BibTeX citation in `README.md` to reference the AAAI 2026 conference proceedings, including new fields such as volume, number, pages, DOI, and official URL.
* Updated the BibTeX citation in `pages/src/pages/index.mdx` to match the official AAAI 2026 publication details.